### PR TITLE
feat: Add main_domain and metadata to validation logs

### DIFF
--- a/app/Http/Controllers/AccessKeyController.php
+++ b/app/Http/Controllers/AccessKeyController.php
@@ -6,16 +6,14 @@ use App\Models\AccessKey;
 use App\Models\ValidationLog;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Validator;
 
 class AccessKeyController extends Controller
 {
     /**
      * Validate an access key
      *
-     * @param Request $request
      * @return \Illuminate\Http\JsonResponse
      */
     public function validate(Request $request)
@@ -28,7 +26,7 @@ class AccessKeyController extends Controller
             'system_fingerprint' => 'nullable|string|max:255',
             'method' => 'required|string|in:GET,POST,PUT,DELETE,PATCH,get,post,put.delete,patch',
             'timestamp' => 'required|integer',
-            'request_id' => 'required|uuid'
+            'request_id' => 'required|uuid',
         ]);
 
         if ($validator->fails()) {
@@ -56,10 +54,10 @@ class AccessKeyController extends Controller
             ]);
         }
 
-        //TODO:  add a check for the referr
+        // TODO:  add a check for the referr
 
         // Implement rate limiting per access key and IP
-        $rateLimitKey = 'ratelimit:' . md5($accessKey . $request->ip());
+        $rateLimitKey = 'ratelimit:'.md5($accessKey.$request->ip());
         $attempts = Cache::get($rateLimitKey, 0);
 
         if ($attempts > 60) { // 100 attempts per hour
@@ -76,7 +74,7 @@ class AccessKeyController extends Controller
         $license = AccessKey::where('key', $accessKey)->first();
 
         // Log this validation attempt regardless of outcome
-        $log = new ValidationLog();
+        $log = new ValidationLog;
         $log->domain = $domain;
         $log->main_domain = $mainDomain;
         $log->access_key = $accessKey;
@@ -91,7 +89,7 @@ class AccessKeyController extends Controller
         $message = '';
         $expiresAt = null;
 
-        if (!$license) {
+        if (! $license) {
             $message = 'Access key not found';
             $log->status = 'invalid';
             $log->message = $message;
@@ -134,7 +132,7 @@ class AccessKeyController extends Controller
         }
 
         // // Check if domain is allowed
-        if (!$this->isDomainAllowed($license, $domain) && !$license->allow_auto_registration) {
+        if (! $this->isDomainAllowed($license, $domain) && ! $license->allow_auto_registration) {
             $message = 'Access key is not valid for this domain';
             $log->status = 'domain_mismatch';
             $log->message = $message;
@@ -150,9 +148,9 @@ class AccessKeyController extends Controller
         // Check for installation limits
         if ($license->max_domains > 0) {
             // Check if this domain is already allowed
-            if (!$this->isDomainAllowed($license, $domain)) {
+            if (! $this->isDomainAllowed($license, $domain)) {
                 // Domain not explicitly allowed, but we might auto-register it
-                if (!$license->hasReachedDomainLimit() && $license->allow_auto_registration) {
+                if (! $license->hasReachedDomainLimit() && $license->allow_auto_registration) {
                     // We're under the limit, so automatically add this domain
                     $wasAdded = $this->handleNewDomain($license, $domain);
 
@@ -208,8 +206,6 @@ class AccessKeyController extends Controller
     /**
      * Check if the domain is allowed for this license
      *
-     * @param AccessKey $license
-     * @param string $domain
      * @return bool
      */
     protected function isDomainAllowed(AccessKey $license, string $domain)
@@ -221,20 +217,18 @@ class AccessKeyController extends Controller
     /**
      * Get unique domains that have been active in the last 30 days
      *
-     * @param string $accessKey
      * @return array
      */
     protected function getActiveDomains(string $accessKey)
     {
         $license = AccessKey::where('key', $accessKey)->first();
+
         return $license ? $license->active_domains : [];
     }
 
     /**
      * Create a response with a signed verification header
      *
-     * @param array $data
-     * @param int $status
      * @return \Illuminate\Http\JsonResponse
      */
     protected function createSignedResponse(array $data, int $status = 200)
@@ -246,7 +240,7 @@ class AccessKeyController extends Controller
         // Generate signature
         $dataString = json_encode($signatureData);
         $accessKey = $data['access_key'] ?? request('access_key');
-        $secret = hash('sha256', $accessKey . '_verification_key');
+        $secret = hash('sha256', $accessKey.'_verification_key');
         $signature = hash_hmac('sha256', $dataString, $secret);
 
         // Return JSON response with signature header
@@ -258,18 +252,16 @@ class AccessKeyController extends Controller
      * Handle new domain registration for an access key
      * Automatically adds domain to allowed list if under max_domains limit
      *
-     * @param AccessKey $license
-     * @param string $domain
      * @return bool Whether the domain was successfully added
      */
     protected function handleNewDomain(AccessKey $license, string $domain)
     {
-        if (!$license->allow_auto_registration) {
+        if (! $license->allow_auto_registration) {
             return false;
         }
 
         // Check if we're within the domain limit
-        if (!$license->hasReachedDomainLimit()) {
+        if (! $license->hasReachedDomainLimit()) {
             // Add the domain
             $added = $license->addAllowedDomain($domain);
 
@@ -296,23 +288,23 @@ class AccessKeyController extends Controller
 
         return false;
     }
+
     /**
      * Get statistics about key usage
      *
-     * @param Request $request
      * @return \Illuminate\Http\JsonResponse
      */
     public function keyStats(Request $request)
     {
         // Require authentication for this endpoint
-        if (!\Auth::user()->can('view access key stats')) {
+        if (! \Auth::user()->can('view access key stats')) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 
         $key = $request->input('key');
         $license = AccessKey::where('key', $key)->first();
 
-        if (!$license) {
+        if (! $license) {
             return response()->json(['error' => 'Key not found'], 404);
         }
 
@@ -330,7 +322,7 @@ class AccessKeyController extends Controller
                 ->selectRaw('DATE(created_at) as date, COUNT(*) as count')
                 ->groupBy('date')
                 ->get()
-                ->pluck('count', 'date')
+                ->pluck('count', 'date'),
         ];
 
         return response()->json($stats);
@@ -339,13 +331,12 @@ class AccessKeyController extends Controller
     /**
      * Reset domain tracking for a key
      *
-     * @param Request $request
      * @return \Illuminate\Http\JsonResponse
      */
     public function resetDomains(Request $request)
     {
         // Require authentication for this endpoint
-        if (!\Auth::user()->can('manage access keys')) {
+        if (! \Auth::user()->can('manage access keys')) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 
@@ -357,22 +348,20 @@ class AccessKeyController extends Controller
 
         return response()->json([
             'success' => true,
-            'message' => 'Domain tracking has been reset for this key'
+            'message' => 'Domain tracking has been reset for this key',
         ]);
     }
-
 
     /**
      * Check if we're in grace period for this license
      * Using the configurable grace period from the license
      *
-     * @param AccessKey $license
-     * @param ValidationLog $lastSuccessLog
+     * @param  ValidationLog  $lastSuccessLog
      * @return bool
      */
     protected function isInGracePeriod(AccessKey $license, $lastSuccessLog)
     {
-        if (!$lastSuccessLog) {
+        if (! $lastSuccessLog) {
             return false;
         }
 
@@ -384,9 +373,8 @@ class AccessKeyController extends Controller
 
     /**
      * Extract the main domain from a full domain string
-     * 
-     * @param string $domain
-     * @return string
+     *
+     * @param  string  $domain
      */
     protected function extractMainDomain(string $host): string
     {
@@ -410,9 +398,10 @@ class AccessKeyController extends Controller
         ];
 
         foreach ($multiPartTLDs as $tld) {
-            if (str_ends_with($host, '.' . $tld)) {
+            if (str_ends_with($host, '.'.$tld)) {
                 $parts = explode('.', $host);
-                $domainParts = array_slice($parts, - ($this->countDots($tld) + 2));
+                $domainParts = array_slice($parts, -($this->countDots($tld) + 2));
+
                 return implode('.', $domainParts);
             }
         }
@@ -422,7 +411,7 @@ class AccessKeyController extends Controller
         $count = count($parts);
 
         if ($count >= 2) {
-            return $parts[$count - 2] . '.' . $parts[$count - 1];
+            return $parts[$count - 2].'.'.$parts[$count - 1];
         }
 
         // Fallback (e.g. localhost or invalid domain)

--- a/app/Http/Controllers/Admin/AuthController.php
+++ b/app/Http/Controllers/Admin/AuthController.php
@@ -25,9 +25,11 @@ class AuthController extends Controller
             // Check if user is an admin
             if (Auth::user()->role === 'admin') {
                 $request->session()->regenerate();
+
                 return redirect()->intended(route('admin.dashboard'));
             } else {
                 Auth::logout();
+
                 return back()->withErrors([
                     'email' => 'You are not authorised.',
                 ]);
@@ -44,6 +46,7 @@ class AuthController extends Controller
         Auth::logout();
         $request->session()->invalidate();
         $request->session()->regenerateToken();
+
         return redirect()->route('admin.login');
     }
 }

--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
-use App\Models\ValidationLog;
 use App\Models\AccessKey;
+use App\Models\ValidationLog;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -63,11 +63,12 @@ class DashboardController extends Controller
             ->get()
             ->map(function ($item) {
                 $key = AccessKey::where('key', $item->access_key)->first();
+
                 return [
                     'key' => $item->access_key,
                     'owner_name' => $key ? $key->owner_name : 'Unknown',
                     'owner_email' => $key ? $key->owner_email : 'Unknown',
-                    'validation_count' => $item->validation_count
+                    'validation_count' => $item->validation_count,
                 ];
             });
 
@@ -103,7 +104,6 @@ class DashboardController extends Controller
     /**
      * Display detailed usage statistics
      *
-     * @param Request $request
      * @return \Illuminate\View\View
      */
     public function usageStats(Request $request)
@@ -212,7 +212,6 @@ class DashboardController extends Controller
     /**
      * Display detailed access key statistics
      *
-     * @param Request $request
      * @return \Illuminate\View\View
      */
     public function keyStats(Request $request)
@@ -290,7 +289,7 @@ class DashboardController extends Controller
             'expired' => $keys->where('is_expired', true)->count(),
             'expiring_soon' => $keys->filter(function ($item) {
                 return $item['key']->expires_at &&
-                    !Carbon::parse($item['key']->expires_at)->isPast() &&
+                    ! Carbon::parse($item['key']->expires_at)->isPast() &&
                     Carbon::parse($item['key']->expires_at)->diffInDays() <= 30;
             })->count(),
             'unused' => $keys->where('total_validations', 0)->count(),
@@ -315,7 +314,6 @@ class DashboardController extends Controller
     /**
      * Display detailed domain statistics
      *
-     * @param Request $request
      * @return \Illuminate\View\View
      */
     public function domainStats(Request $request)

--- a/app/Http/Controllers/Admin/LicenseController.php
+++ b/app/Http/Controllers/Admin/LicenseController.php
@@ -15,7 +15,6 @@ class LicenseController extends Controller
     /**
      * Display a listing of all access keys
      *
-     * @param Request $request
      * @return \Illuminate\View\View
      */
     public function index(Request $request)
@@ -71,7 +70,7 @@ class LicenseController extends Controller
                 ->whereNotNull('expires_at')
                 ->where('expires_at', '<', Carbon::now())
                 ->count(),
-            'revoked' => AccessKey::where('revoked', true)->count()
+            'revoked' => AccessKey::where('revoked', true)->count(),
         ];
 
         $tiers = AccessKey::distinct('tier')->pluck('tier');
@@ -92,7 +91,6 @@ class LicenseController extends Controller
     /**
      * Store a newly created access key
      *
-     * @param Request $request
      * @return \Illuminate\Http\RedirectResponse
      */
     public function store(Request $request)
@@ -127,7 +125,7 @@ class LicenseController extends Controller
         }
 
         // Create the new access key
-        $accessKey = new AccessKey();
+        $accessKey = new AccessKey;
         $accessKey->key = Str::uuid();
         $accessKey->owner_name = $request->owner_name;
         $accessKey->owner_email = $request->owner_email;
@@ -149,7 +147,7 @@ class LicenseController extends Controller
     /**
      * Display the specified access key
      *
-     * @param string $id
+     * @param  string  $id
      * @return \Illuminate\View\View
      */
     public function show($id)
@@ -193,7 +191,7 @@ class LicenseController extends Controller
     /**
      * Show form for editing the specified access key
      *
-     * @param string $id
+     * @param  string  $id
      * @return \Illuminate\View\View
      */
     public function edit($id)
@@ -202,7 +200,7 @@ class LicenseController extends Controller
 
         // Format domains as text for textarea
         $domainsText = '';
-        if (!empty($key->allowed_domains) && is_array($key->allowed_domains)) {
+        if (! empty($key->allowed_domains) && is_array($key->allowed_domains)) {
             $domainsText = implode("\n", $key->allowed_domains);
         }
 
@@ -212,8 +210,7 @@ class LicenseController extends Controller
     /**
      * Update the specified access key
      *
-     * @param Request $request
-     * @param string $id
+     * @param  string  $id
      * @return \Illuminate\Http\RedirectResponse
      */
     public function update(Request $request, $id)
@@ -270,7 +267,7 @@ class LicenseController extends Controller
     /**
      * Remove the specified access key
      *
-     * @param string $id
+     * @param  string  $id
      * @return \Illuminate\Http\RedirectResponse
      */
     public function destroy($id)
@@ -288,8 +285,7 @@ class LicenseController extends Controller
     /**
      * Revoke the specified access key
      *
-     * @param Request $request
-     * @param string $id
+     * @param  string  $id
      * @return \Illuminate\Http\RedirectResponse
      */
     public function revoke(Request $request, $id)
@@ -317,7 +313,7 @@ class LicenseController extends Controller
     /**
      * Restore a revoked access key
      *
-     * @param string $id
+     * @param  string  $id
      * @return \Illuminate\Http\RedirectResponse
      */
     public function restore($id)
@@ -335,7 +331,7 @@ class LicenseController extends Controller
     /**
      * Reset domain tracking for a key
      *
-     * @param string $id
+     * @param  string  $id
      * @return \Illuminate\Http\RedirectResponse
      */
     public function resetDomains($id)
@@ -353,8 +349,7 @@ class LicenseController extends Controller
     /**
      * Extend the validity of an access key
      *
-     * @param Request $request
-     * @param string $id
+     * @param  string  $id
      * @return \Illuminate\Http\RedirectResponse
      */
     public function extendValidity(Request $request, $id)
@@ -391,8 +386,7 @@ class LicenseController extends Controller
     /**
      * Manage allowed domains for a key
      *
-     * @param Request $request
-     * @param string $id
+     * @param  string  $id
      * @return \Illuminate\Http\RedirectResponse
      */
     public function manageDomains(Request $request, $id)
@@ -405,15 +399,17 @@ class LicenseController extends Controller
         if ($action === 'add' && $request->filled('new_domain')) {
             $newDomain = trim($request->input('new_domain'));
             $key->addAllowedDomain($newDomain);
+
             return redirect()->route('admin.access-keys.show', $key->id)
                 ->with('success', "Domain '{$newDomain}' added successfully.");
         } elseif ($action === 'remove' && $domain) {
             $key->removeAllowedDomain($domain);
+
             return redirect()->route('admin.access-keys.show', $key->id)
                 ->with('success', "Domain '{$domain}' removed successfully.");
         }
 
         return redirect()->route('admin.access-keys.show', $key->id)
-            ->with('error', "Invalid domain management action.");
+            ->with('error', 'Invalid domain management action.');
     }
 }

--- a/app/Http/Controllers/Admin/ProfileController.php
+++ b/app/Http/Controllers/Admin/ProfileController.php
@@ -23,7 +23,7 @@ class ProfileController extends Controller
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
             'current_password' => ['nullable', 'required_with:password', function ($attribute, $value, $fail) use ($user) {
-                if (!Hash::check($value, $user->password)) {
+                if (! Hash::check($value, $user->password)) {
                     $fail('The current password is incorrect.');
                 }
             }],

--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -14,9 +14,10 @@ class SettingsController extends Controller
     {
         return view('admin.settings.index', [
             'settings' => Setting::firstOrNew(),
-            'title' => 'General Settings'
+            'title' => 'General Settings',
         ]);
     }
+
     public function update(Request $request)
     {
         $settings = Setting::firstOrNew();
@@ -25,14 +26,14 @@ class SettingsController extends Controller
         $input['registration_active'] = $request->boolean('registration_active');
         if ($request->hasFile('favicon')) {
             $image = $request->file('favicon');
-            $imageName = \Str::random(5) . '-favicon.png';
+            $imageName = \Str::random(5).'-favicon.png';
             $image->move(public_path('uploads'), $imageName);
             $input['favicon'] = $imageName;
         }
 
         if ($request->hasFile('logo')) {
             $image = $request->file('logo');
-            $imageName = \Str::random(5) . '-logo.png';
+            $imageName = \Str::random(5).'-logo.png';
             $image->move(public_path('uploads'), $imageName);
             $input['logo'] = $imageName;
         }
@@ -50,7 +51,7 @@ class SettingsController extends Controller
     {
         return view('admin.settings.index', [
             'tiers' => LicenseTier::orderBy('order')->get(),
-            'title' => 'License Tiers'
+            'title' => 'License Tiers',
         ]);
     }
 

--- a/app/Http/Controllers/Admin/ValidationLogController.php
+++ b/app/Http/Controllers/Admin/ValidationLogController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
-use App\Models\ValidationLog;
 use App\Models\AccessKey;
+use App\Models\ValidationLog;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Response;
@@ -14,7 +14,6 @@ class ValidationLogController extends Controller
     /**
      * Display a listing of all validation logs
      *
-     * @param Request $request
      * @return \Illuminate\View\View
      */
     public function index(Request $request)
@@ -27,7 +26,7 @@ class ValidationLogController extends Controller
         }
 
         if ($request->filled('domain')) {
-            $query->where('domain', 'like', '%' . $request->domain . '%');
+            $query->where('domain', 'like', '%'.$request->domain.'%');
         }
 
         if ($request->filled('status')) {
@@ -43,7 +42,7 @@ class ValidationLogController extends Controller
         }
 
         if ($request->filled('ip')) {
-            $query->where('ip_address', 'like', '%' . $request->ip . '%');
+            $query->where('ip_address', 'like', '%'.$request->ip.'%');
         }
 
         // Sorting
@@ -60,7 +59,7 @@ class ValidationLogController extends Controller
             ->map(function ($key) {
                 return [
                     'key' => $key->key,
-                    'label' => "{$key->owner_name} ({$key->owner_email}) - {$key->key}"
+                    'label' => "{$key->owner_name} ({$key->owner_email}) - {$key->key}",
                 ];
             });
 
@@ -79,7 +78,7 @@ class ValidationLogController extends Controller
     /**
      * Display logs for a specific domain
      *
-     * @param string $domain
+     * @param  string  $domain
      * @return \Illuminate\View\View
      */
     public function byDomain($domain)
@@ -104,7 +103,7 @@ class ValidationLogController extends Controller
     /**
      * Display logs for a specific access key
      *
-     * @param string $access_key
+     * @param  string  $access_key
      * @return \Illuminate\View\View
      */
     public function byKey($access_key)
@@ -132,7 +131,7 @@ class ValidationLogController extends Controller
     /**
      * Display logs for a specific status
      *
-     * @param string $status
+     * @param  string  $status
      * @return \Illuminate\View\View
      */
     public function byStatus($status)
@@ -169,7 +168,6 @@ class ValidationLogController extends Controller
     /**
      * Search for logs
      *
-     * @param Request $request
      * @return \Illuminate\View\View
      */
     public function search(Request $request)
@@ -193,7 +191,6 @@ class ValidationLogController extends Controller
     /**
      * Export logs as CSV
      *
-     * @param Request $request
      * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
      */
     public function export(Request $request)
@@ -206,7 +203,7 @@ class ValidationLogController extends Controller
         }
 
         if ($request->filled('domain')) {
-            $query->where('domain', 'like', '%' . $request->domain . '%');
+            $query->where('domain', 'like', '%'.$request->domain.'%');
         }
 
         if ($request->filled('status')) {
@@ -225,7 +222,7 @@ class ValidationLogController extends Controller
         $logs = $query->orderBy('created_at', 'desc')->limit(10000)->get();
 
         // Create CSV
-        $filename = 'validation_logs_' . date('Y-m-d_His') . '.csv';
+        $filename = 'validation_logs_'.date('Y-m-d_His').'.csv';
         $headers = [
             'Content-Type' => 'text/csv',
             'Content-Disposition' => "attachment; filename=\"{$filename}\"",
@@ -254,7 +251,7 @@ class ValidationLogController extends Controller
     /**
      * Delete a specific log entry
      *
-     * @param string $id
+     * @param  string  $id
      * @return \Illuminate\Http\RedirectResponse
      */
     public function destroy($id)
@@ -265,7 +262,7 @@ class ValidationLogController extends Controller
         if (request()->ajax() || request()->wantsJson()) {
             return response()->json([
                 'success' => true,
-                'message' => 'Log entry deleted successfully'
+                'message' => 'Log entry deleted successfully',
             ]);
         }
 
@@ -276,7 +273,6 @@ class ValidationLogController extends Controller
     /**
      * Clean up old log entries
      *
-     * @param Request $request
      * @return \Illuminate\Http\RedirectResponse
      */
     public function cleanup(Request $request)

--- a/app/Http/Helpers/Helper.php
+++ b/app/Http/Helpers/Helper.php
@@ -24,10 +24,10 @@ if (! function_exists('static_asset')) {
     function static_asset($path, $secure = null)
     {
         if (php_sapi_name() == 'cli-server') {
-            return app('url')->asset('assets/' . $path, $secure);
+            return app('url')->asset('assets/'.$path, $secure);
         }
 
-        return app('url')->asset('public/assets/' . $path, $secure);
+        return app('url')->asset('public/assets/'.$path, $secure);
     }
 }
 
@@ -36,9 +36,9 @@ if (! function_exists('my_asset')) {
     function my_asset($path, $secure = null)
     {
         if (php_sapi_name() == 'cli-server') {
-            return app('url')->asset('uploads/' . $path, $secure);
+            return app('url')->asset('uploads/'.$path, $secure);
         }
 
-        return app('url')->asset('public/uploads/' . $path, $secure);
+        return app('url')->asset('public/uploads/'.$path, $secure);
     }
 }

--- a/app/Http/Middleware/Admin.php
+++ b/app/Http/Middleware/Admin.php
@@ -21,6 +21,7 @@ class Admin
         }
         // Logout
         Auth::logout();
+
         return redirect()->route('admin.login')->with('error', 'You are not authorised access.');
     }
 }

--- a/app/Models/AccessKey.php
+++ b/app/Models/AccessKey.php
@@ -39,6 +39,7 @@ class AccessKey extends Model
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];
+
     /**
      * Get the validation logs for the access key
      */
@@ -73,7 +74,7 @@ class AccessKey extends Model
 
         $allowedDomains = $this->allowed_domains;
 
-        if (!is_array($allowedDomains)) {
+        if (! is_array($allowedDomains)) {
             return true; // Fallback in case of data corruption
         }
 
@@ -86,7 +87,7 @@ class AccessKey extends Model
             // Handle wildcards
             if (strpos($allowedDomain, '*') !== false) {
                 $pattern = str_replace('\*', '.*', preg_quote($allowedDomain, '/'));
-                if (preg_match('/^' . $pattern . '$/i', $domain)) {
+                if (preg_match('/^'.$pattern.'$/i', $domain)) {
                     return true;
                 }
             } else {
@@ -106,7 +107,7 @@ class AccessKey extends Model
     {
         $allowedDomains = $this->allowed_domains ?: [];
 
-        if (!in_array($domain, $allowedDomains)) {
+        if (! in_array($domain, $allowedDomains)) {
             $allowedDomains[] = $domain;
             $this->allowed_domains = $allowedDomains;
             $this->save();
@@ -164,7 +165,7 @@ class AccessKey extends Model
      */
     public function getDaysUntilExpirationAttribute()
     {
-        if (!$this->expires_at) {
+        if (! $this->expires_at) {
             return null;
         }
 

--- a/app/Models/LicenseTier.php
+++ b/app/Models/LicenseTier.php
@@ -11,7 +11,7 @@ class LicenseTier extends Model
         'price',
         'duration',
         'status',
-        'order'
+        'order',
     ];
 
     protected $casts = [

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -38,7 +38,7 @@ class Setting extends Model
         'registration_active',
         'default_license_term',
         'max_domains_per_license',
-        'license_expiration_alert'
+        'license_expiration_alert',
     ];
 
     protected $casts = [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -46,6 +46,7 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
     /**
      * Check if the user is an admin.
      *

--- a/app/Models/ValidationLog.php
+++ b/app/Models/ValidationLog.php
@@ -24,6 +24,8 @@ class ValidationLog extends Model
         'auto_registered',
         'reset_domains',
         'registration_date',
+        'main_domain',
+        'metadata',
     ];
 
     protected $casts = [
@@ -31,6 +33,7 @@ class ValidationLog extends Model
         'auto_registered' => 'boolean',
         'reset_domains' => 'boolean',
         'registration_date' => 'datetime',
+        'metadata' => 'json',
     ];
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -9,9 +9,9 @@ use Illuminate\Http\Request;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
-        web: __DIR__ . '/../routes/web.php',
-        api: __DIR__ . '/../routes/api.php',
-        commands: __DIR__ . '/../routes/console.php',
+        web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
+        commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
@@ -20,12 +20,12 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
 
         $middleware->alias([
-            'admin'       => \App\Http\Middleware\Admin::class,
+            'admin' => \App\Http\Middleware\Admin::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         $exceptions->render(function (Throwable $exception, Request $request) {
-            return (new ExceptionHandler())->handle($exception, $request);
+            return (new ExceptionHandler)->handle($exception, $request);
 
             return parent::render($request, $exception);
         });

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
-            $table->enum('role',['user','admin'])->default('user');
+            $table->enum('role', ['user', 'admin'])->default('user');
             $table->rememberToken();
             $table->timestamps();
         });

--- a/database/migrations/2025_04_12_005604_create_access_keys_table.php
+++ b/database/migrations/2025_04_12_005604_create_access_keys_table.php
@@ -23,7 +23,7 @@ return new class extends Migration
             $table->json('metadata')->nullable(); // JSON array of additional metadata
             $table->timestamp('expires_at')->nullable();
             $table->timestamp('last_used_at')->nullable();
-            $table->enum('status', ['active','revoked','expired','pending'])->default('active');
+            $table->enum('status', ['active', 'revoked', 'expired', 'pending'])->default('active');
             $table->boolean('revoked')->default(false);
             $table->text('revocation_reason')->nullable();
             $table->boolean('allow_auto_registration')->default(true);

--- a/database/migrations/2025_05_15_034924_add_fields_to_validation_logs_table.php
+++ b/database/migrations/2025_05_15_034924_add_fields_to_validation_logs_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('validation_logs', function (Blueprint $table) {
+            $table->json('metadata')->nullable();
+            $table->string('main_domain')->nullable()->after('domain');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('validation_logs', function (Blueprint $table) {
+            $table->dropColumn([ 'metadata', 'main_domain']);
+        });
+    }
+};

--- a/database/migrations/2025_05_15_034924_add_fields_to_validation_logs_table.php
+++ b/database/migrations/2025_05_15_034924_add_fields_to_validation_logs_table.php
@@ -23,7 +23,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('validation_logs', function (Blueprint $table) {
-            $table->dropColumn([ 'metadata', 'main_domain']);
+            $table->dropColumn(['metadata', 'main_domain']);
         });
     }
 };

--- a/resources/views/admin/logs/partials/logs-table.blade.php
+++ b/resources/views/admin/logs/partials/logs-table.blade.php
@@ -23,18 +23,22 @@
                 <tr>
                     <td>{{ $log->created_at->format('M j, Y H:i') }}</td>
                     <td class="font-mono text-sm">
-                        <a href="{{ route('admin.logs.by-domain', $log->domain) }}" class="text-blue-600 hover:underline hover:text-blue-800">
+                        <a href="{{ route('admin.logs.by-domain', $log->domain) }}"
+                            class="text-blue-600 hover:underline hover:text-blue-800">
                             {{ $log->domain }}
                         </a>
+                        <p class="text-gray-500">Main: {{ $log->main_domain ?? 'N/A' }}</p>
                     </td>
                     <td class="font-mono text-sm">
-                        <a href="{{ route('admin.logs.by-key', $log->access_key) }}" class="text-blue-600 hover:underline">
+                        <a href="{{ route('admin.logs.by-key', $log->access_key) }}"
+                            class="text-blue-600 hover:underline">
                             {{ Str::limit($log->access_key, 8) }}
                         </a>
                     </td>
                     <td class="font-mono text-sm">{{ $log->ip_address }}</td>
                     <td>
-                        <a href="{{ route('admin.logs.by-status', Str::slug($log->status)) }}" class="hover:opacity-75 transition-opacity">
+                        <a href="{{ route('admin.logs.by-status', Str::slug($log->status)) }}"
+                            class="hover:opacity-75 transition-opacity">
                             <span class="badge {{ $log->status === 'valid' ? 'bg-green-500' : 'bg-red-500' }}">
                                 {{ ucfirst($log->status) }}
                             </span>
@@ -48,66 +52,101 @@
                         @endif
                     </td>
                     <td>
-                        <a href="#" class="text-red-500 hover:text-red-700 delete-log" data-url="{{ route('admin.logs.destroy', $log->id) }}">
+                        <a href="#" class="text-red-500 hover:text-red-700 delete-log"
+                            data-url="{{ route('admin.logs.destroy', $log->id) }}">
                             <i class="fas fa-trash"></i>
                         </a>
+                        <!-- View Metadata -->
+                        <button
+                            class="text-blue-500 hover:text-blue-700 view-metadata inline-flex items-center justify-center w-8 h-8 rounded-full hover:bg-blue-100 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-300"
+                            data-log='@json($log->metadata)'>
+                            <i class="fas fa-eye text-base"></i>
+                        </button>
                     </td>
                 </tr>
             @empty
                 <tr>
-                    <td colspan="7" class="text-center py-4 text-gray-500">
-                        No logs found matching your criteria
-                    </td>
+                    <td colspan="8" class="text-center py-4 text-gray-500" No logs found matching your criteria </td>
                 </tr>
             @endforelse
         </tbody>
     </table>
 </div>
+<!-- Metadata Modal -->
+<div id="metadataModal" class="fixed inset-0 z-50 hidden bg-black bg-opacity-50 flex items-center justify-center">
+    <div class="bg-white w-full max-w-lg rounded-lg shadow-lg p-6 relative">
+        <button id="closeModal"
+            class="absolute top-2 right-3 text-gray-500 hover:text-gray-700 text-xl">&times;</button>
+        <h2 class="text-xl font-semibold mb-4">Log Metadata</h2>
+
+        <div class="pt-2" style="max-height: 300px; overflow-y: auto; border: 1px solid #ddd; padding: 10px;">
+            <pre id="metadataContent" class="text-sm font-mono text-gray-800 whitespace-pre-wrap"></pre>
+        </div>
+    </div>
+</div>
 
 @push('scripts')
-<script>
-    document.addEventListener('DOMContentLoaded', function() {
-        // Delete log handler
-        document.querySelectorAll('.delete-log').forEach(button => {
-            button.addEventListener('click', function(e) {
-                e.preventDefault();
-                const url = this.dataset.url;
-                const row = this.closest('tr');
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
 
-                // SweetAlert2 for confirmation
-                Swal.fire({
-                    title: 'Are you sure?',
-                    text: "You won't be able to revert this!",
-                    icon: 'warning',
-                    showCancelButton: true,
-                    confirmButtonColor: '#d33',
-                    cancelButtonColor: '#3085d6',
-                    confirmButtonText: 'Yes, delete it!'
-                }).then((result) => {
-                    if (result.isConfirmed) {
-                        // AJAX request
-                        axios.delete(url, {
-                            headers: {
-                                'X-CSRF-TOKEN': '{{ csrf_token() }}',
-                                'X-Requested-With': 'XMLHttpRequest'
-                            }
-                        })
-                        .then(response => {
-                            if (response.data.success) {
-                                // Remove row from table
-                                row.remove();
-                                // Toastr success notification
-                                toastr.success(response.data.message);
-                            }
-                        })
-                        .catch(error => {
-                            // Toastr error notification
-                            toastr.error(error.response?.data?.message || 'Something went wrong');
-                        });
-                    }
+            const modal = document.getElementById('metadataModal');
+            const content = document.getElementById('metadataContent');
+            const closeModal = document.getElementById('closeModal');
+
+            // Open modal and show metadata
+            document.querySelectorAll('.view-metadata').forEach(button => {
+                button.addEventListener('click', function() {
+                    const metadata = JSON.parse(this.dataset.metadata || '{}');
+
+                    // Pretty print JSON
+                    content.textContent = JSON.stringify(metadata, null, 4);
+
+                    modal.classList.remove('hidden');
+                });
+            });
+
+            // Close modal on button click or backdrop click
+            closeModal.addEventListener('click', () => modal.classList.add('hidden'));
+            modal.addEventListener('click', (e) => {
+                if (e.target === modal) modal.classList.add('hidden');
+            });
+            // Delete Log (your existing code remains unchanged)
+            document.querySelectorAll('.delete-log').forEach(button => {
+                button.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    const url = this.dataset.url;
+                    const row = this.closest('tr');
+
+                    Swal.fire({
+                        title: 'Are you sure?',
+                        text: "You won't be able to revert this!",
+                        icon: 'warning',
+                        showCancelButton: true,
+                        confirmButtonColor: '#d33',
+                        cancelButtonColor: '#3085d6',
+                        confirmButtonText: 'Yes, delete it!'
+                    }).then((result) => {
+                        if (result.isConfirmed) {
+                            axios.delete(url, {
+                                    headers: {
+                                        'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                                        'X-Requested-With': 'XMLHttpRequest'
+                                    }
+                                })
+                                .then(response => {
+                                    if (response.data.success) {
+                                        row.remove();
+                                        toastr.success(response.data.message);
+                                    }
+                                })
+                                .catch(error => {
+                                    toastr.error(error.response?.data?.message ||
+                                        'Something went wrong');
+                                });
+                        }
+                    });
                 });
             });
         });
-    });
     </script>
 @endpush

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,4 +11,3 @@ Route::get('/user', function (Request $request) {
 Route::middleware(['throttle:30,1'])->group(function () {
     Route::post('/validate', [AccessKeyController::class, 'validate']);
 });
-


### PR DESCRIPTION
Adds main_domain and metadata fields to the validation logs table to provide more context for debugging. Also adds logic to extract main domain from domain and store all metadata.

## Summary by Sourcery

Add main_domain and metadata fields to validation logs, populate them during validation requests, and provide a helper to extract the base domain from a full host string

New Features:
- Add main_domain and metadata fields to the validation_logs table
- Log full request metadata and derived main domain for each validation attempt
- Implement extractMainDomain helper to parse the base domain from a host string

Enhancements:
- Update ValidationLog model to include new fields and cast metadata as JSON