### PR TITLE
feat: Add metadata and main_domain fields to validation logs

### DIFF
--- a/database/migrations/2025_05_15_034924_add_fields_to_validation_logs_table.php
+++ b/database/migrations/2025_05_15_034924_add_fields_to_validation_logs_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('validation_logs', function (Blueprint $table) {
-            $table->json('metadata')->nullable();
+            $table->json('metadata')->nullable()->after('registration_date');
             $table->string('main_domain')->nullable()->after('domain');
         });
     }

--- a/resources/views/admin/logs/partials/logs-table.blade.php
+++ b/resources/views/admin/logs/partials/logs-table.blade.php
@@ -96,7 +96,7 @@
             // Open modal and show metadata
             document.querySelectorAll('.view-metadata').forEach(button => {
                 button.addEventListener('click', function() {
-                    const metadata = JSON.parse(this.dataset.metadata || '{}');
+                    const metadata = JSON.parse(this.dataset.log || '{}');
 
                     // Pretty print JSON
                     content.textContent = JSON.stringify(metadata, null, 4);


### PR DESCRIPTION
The metadata field stores additional information and the main_domain field stores the main domain associated with the log.
Also, fix the javascript to parse the correct dataset

## Summary by Sourcery

Add metadata and main_domain fields to the validation_logs table and correct the front-end metadata parsing

New Features:
- Add nullable JSON metadata column to validation_logs
- Add nullable string main_domain column to validation_logs

Bug Fixes:
- Fix JavaScript to parse metadata from the data-log attribute instead of data-metadata